### PR TITLE
Fix README view size on GitHub

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -4,7 +4,9 @@
 
 1. CD into Sublime Text packages folder
 
-    `cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages or cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages`
+    `cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages`
+     or 
+    `cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages`
 
 
 2. Clone repository into packages folder


### PR DESCRIPTION
Github it's cutting the content of the command when showing the README information. This PR fix that error.

Image with the bug: http://f.cl.ly/items/1O1q1n2R1V3f0b182Z0F/bug.png
