### PR TITLE
Fixed numbering of steps for MacOSX install instructions.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -6,12 +6,11 @@
 
 1. CD into Sublime Text packages folder
 
-`cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages`
+    `cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages`
 
-or
+  or
 
-`cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages`
-
+    `cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages`
 
 2. Clone repository into packages folder
 


### PR DESCRIPTION
There was a formatting issue that caused step "2" to render as "1". It was indeed "2" in the code, but because the back-tick blocks were indented at the same level as the number 1, it was causing the second number to count as the start of a new list, and thus receive no. "1". I fixed that, and now it indeed says both step "1", and "2" for install instructions on the Mac.