### PR TITLE
Fixed missing hamburger icon issue

### DIFF
--- a/Snippets/Sublime Snippets/Snippet.topbar.sublime-snippet
+++ b/Snippets/Sublime Snippets/Snippet.topbar.sublime-snippet
@@ -5,7 +5,7 @@
       <li class="name">
         <h1><a href="#">Something</a></h1>
       </li>
-      <li class="toggle-topbar menu-icon"><a href="#">Menu</a></li>
+      <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
     </ul>
 
   <section class="top-bar-section">


### PR DESCRIPTION
By wrapping the word 'Menu' in a `span` element, the hamburger icon now appears in mobile layout.