### PR TITLE
fix iconbar-horizontal snippet

### DIFF
--- a/Snippets/Sublime Snippets/Snippet.iconbar-horizontal.sublime-snippet
+++ b/Snippets/Sublime Snippets/Snippet.iconbar-horizontal.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
   <content><![CDATA[
-  <div class="icon-bar four-up">
+<div class="icon-bar four-up">
   <a class="item">
-    <img src="<img src="http://placehold.it/25x25">
+    <img src="http://placehold.it/25x25">
     <label>Home</label>
   </a>
   <a class="item">


### PR DESCRIPTION
Fixes small errors in the iconbar-horizontal snippet. First icon now displays properly.
